### PR TITLE
risc0 customization of rust's nightly-2022-08-16 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,6 +3295,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-zkvm-platform"
+version = "0.10.0"
+dependencies = [
+ "compiler_builtins",
+ "rustc-std-workspace-core",
+]
+
+[[package]]
 name = "rls"
 version = "1.41.0"
 dependencies = [
@@ -5066,6 +5074,7 @@ dependencies = [
  "panic_unwind",
  "profiler_builtins",
  "rand 0.7.3",
+ "risc0-zkvm-platform",
  "rustc-demangle",
  "std_detect",
  "unwind",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3296,7 +3296,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.10.0"
+version = "0.11.1"
+source = "git+https://github.com/risc0/risc0?rev=d568b2d517e49e3fbe4d6db1e9f963e44b86c67f#d568b2d517e49e3fbe4d6db1e9f963e44b86c67f"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -991,6 +991,7 @@ supported_targets! {
 
     ("riscv32i-unknown-none-elf", riscv32i_unknown_none_elf),
     ("riscv32im-unknown-none-elf", riscv32im_unknown_none_elf),
+    ("riscv32im-risc0-zkvm-elf", riscv32im_risc0_zkvm_elf),
     ("riscv32imc-unknown-none-elf", riscv32imc_unknown_none_elf),
     ("riscv32imc-esp-espidf", riscv32imc_esp_espidf),
     ("riscv32imac-unknown-none-elf", riscv32imac_unknown_none_elf),

--- a/compiler/rustc_target/src/spec/riscv32im_risc0_zkvm_elf.rs
+++ b/compiler/rustc_target/src/spec/riscv32im_risc0_zkvm_elf.rs
@@ -1,0 +1,36 @@
+use crate::spec::{LinkerFlavor, LldFlavor, PanicStrategy, RelocModel};
+use crate::spec::{Target, TargetOptions};
+
+pub fn target() -> Target {
+    Target {
+        data_layout: "e-m:e-p:32:32-i64:64-n32-S128".into(),
+        llvm_target: "riscv32".into(),
+        pointer_width: 32,
+        arch: "riscv32".into(),
+
+        options: TargetOptions {
+            os: "zkvm".into(),
+            vendor: "risc0".into(),
+            linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
+            linker: Some("rust-lld".into()),
+            cpu: "generic-rv32".into(),
+
+            // Some crates (*cough* crossbeam) assume you have 64 bit
+            // atomics if the target name is not in a hardcoded list.
+            // Since zkvm is singlethreaded and all operations are
+            // atomic, I guess we can just say we support 64-bit
+            // atomics.
+            max_atomic_width: Some(64),
+            atomic_cas: true,
+
+            features: "+m".into(),
+            executables: true,
+            panic_strategy: PanicStrategy::Abort,
+            relocation_model: RelocModel::Static,
+            emit_debug_gdb_scripts: false,
+            eh_frame_header: false,
+            singlethread: true,
+            ..Default::default()
+        },
+    }
+}

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -47,6 +47,9 @@ hermit-abi = { version = "0.2.0", features = ['rustc-dep-of-std'] }
 [target.wasm32-wasi.dependencies]
 wasi = { version = "0.11.0", features = ['rustc-dep-of-std'], default-features = false }
 
+[target.'cfg(target_os = "zkvm")'.dependencies]
+risc0-zkvm-platform = { git = "https://github.com/risc0/risc0", rev="190ccd595c078a1344568c496caafcfdb492394f", default-features = false, features = ['rustc-dep-of-std'] }
+
 [features]
 backtrace = [
   "gimli-symbolize",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -48,7 +48,7 @@ hermit-abi = { version = "0.2.0", features = ['rustc-dep-of-std'] }
 wasi = { version = "0.11.0", features = ['rustc-dep-of-std'], default-features = false }
 
 [target.'cfg(target_os = "zkvm")'.dependencies]
-risc0-zkvm-platform = { git = "https://github.com/risc0/risc0", rev="190ccd595c078a1344568c496caafcfdb492394f", default-features = false, features = ['rustc-dep-of-std'] }
+risc0-zkvm-platform = { git = "https://github.com/risc0/risc0", rev="d568b2d517e49e3fbe4d6db1e9f963e44b86c67f", default-features = false, features = ['rustc-dep-of-std'] }
 
 [features]
 backtrace = [

--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -31,6 +31,7 @@ fn main() {
         || target.contains("espidf")
         || target.contains("solid")
         || target.contains("nintendo-3ds")
+        || target.contains("zkvm")
     {
         // These platforms don't have any special requirements.
     } else {

--- a/library/std/src/sys/common/alloc.rs
+++ b/library/std/src/sys/common/alloc.rs
@@ -14,7 +14,7 @@ use crate::ptr;
     target_arch = "asmjs",
     target_arch = "wasm32",
     target_arch = "hexagon",
-    all(target_arch = "riscv32", not(target_os = "espidf")),
+    all(target_arch = "riscv32", not(any(target_os = "espidf", target_os = "zkvm"))),
     all(target_arch = "xtensa", not(target_os = "espidf")),
 )))]
 pub const MIN_ALIGN: usize = 8;
@@ -28,9 +28,9 @@ pub const MIN_ALIGN: usize = 8;
     target_arch = "wasm64",
 )))]
 pub const MIN_ALIGN: usize = 16;
-// The allocator on the esp-idf platform guarantees 4 byte alignment.
+// The allocator on the esp-idf and zkvm platforms guarantee 4 byte alignment.
 #[cfg(all(any(
-    all(target_arch = "riscv32", target_os = "espidf"),
+    all(target_arch = "riscv32", any(target_os = "espidf", target_os = "zkvm")),
     all(target_arch = "xtensa", target_os = "espidf"),
 )))]
 pub const MIN_ALIGN: usize = 4;

--- a/library/std/src/sys/mod.rs
+++ b/library/std/src/sys/mod.rs
@@ -43,6 +43,9 @@ cfg_if::cfg_if! {
     } else if #[cfg(target_family = "wasm")] {
         mod wasm;
         pub use self::wasm::*;
+    } else if #[cfg(target_os = "zkvm")] {
+        mod zkvm;
+        pub use self::zkvm::*;
     } else if #[cfg(all(target_vendor = "fortanix", target_env = "sgx"))] {
         mod sgx;
         pub use self::sgx::*;

--- a/library/std/src/sys/zkvm/alloc.rs
+++ b/library/std/src/sys/zkvm/alloc.rs
@@ -1,0 +1,36 @@
+use crate::alloc::{GlobalAlloc, Layout, System};
+use crate::cell::UnsafeCell;
+use risc0_zkvm_platform::{memory, WORD_SIZE};
+
+struct BumpPointerAlloc {
+    head: UnsafeCell<usize>,
+    end: usize,
+}
+// SAFETY: single threaded environment
+unsafe impl Sync for BumpPointerAlloc {}
+
+static mut HEAP: BumpPointerAlloc =
+    BumpPointerAlloc { head: UnsafeCell::new(memory::HEAP.start()), end: memory::HEAP.end() };
+
+#[stable(feature = "alloc_system_type", since = "1.28.0")]
+unsafe impl GlobalAlloc for System {
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let head = HEAP.head.get();
+
+        // move start up to the next alignment boundary
+        let alloc_start = (*head + WORD_SIZE) & !(WORD_SIZE - 1);
+        let alloc_end = alloc_start.checked_add(layout.size()).unwrap();
+        if alloc_end > HEAP.end {
+            panic!("out of heap");
+        } else {
+            *head = alloc_end;
+            alloc_start as *mut u8
+        }
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {
+        // this allocator never deallocates memory
+    }
+}

--- a/library/std/src/sys/zkvm/env.rs
+++ b/library/std/src/sys/zkvm/env.rs
@@ -1,0 +1,9 @@
+pub mod os {
+    pub const FAMILY: &str = "";
+    pub const OS: &str = "";
+    pub const DLL_PREFIX: &str = "";
+    pub const DLL_SUFFIX: &str = ".elf";
+    pub const DLL_EXTENSION: &str = "elf";
+    pub const EXE_SUFFIX: &str = ".elf";
+    pub const EXE_EXTENSION: &str = "elf";
+}

--- a/library/std/src/sys/zkvm/mod.rs
+++ b/library/std/src/sys/zkvm/mod.rs
@@ -1,0 +1,45 @@
+//! System bindings for the risc0 zkvm platform
+//!
+//! This module contains the facade (aka platform-specific) implementations of
+//! OS level functionality for zkvm.
+//!
+//! This is all super highly experimental and not actually intended for
+//! wide/production use yet, it's still all in the experimental category. This
+//! will likely change over time.
+
+pub mod alloc;
+#[path = "../unsupported/args.rs"]
+pub mod args;
+#[path = "../unix/cmath.rs"]
+pub mod cmath;
+pub mod env;
+#[path = "../unsupported/fs.rs"]
+pub mod fs;
+#[path = "../unsupported/io.rs"]
+pub mod io;
+#[path = "../unsupported/net.rs"]
+pub mod net;
+#[path = "../unsupported/os.rs"]
+pub mod os;
+#[path = "../unix/os_str.rs"]
+pub mod os_str;
+#[path = "../unix/path.rs"]
+pub mod path;
+#[path = "../unsupported/pipe.rs"]
+pub mod pipe;
+#[path = "../unsupported/process.rs"]
+pub mod process;
+pub mod stdio;
+pub mod thread_local_key;
+#[path = "../unsupported/time.rs"]
+pub mod time;
+
+#[path = "../unsupported/locks/mod.rs"]
+pub mod locks;
+#[path = "../unsupported/thread.rs"]
+pub mod thread;
+
+#[path = "../unsupported/common.rs"]
+#[deny(unsafe_op_in_unsafe_fn)]
+mod common;
+pub use common::*;

--- a/library/std/src/sys/zkvm/stdio.rs
+++ b/library/std/src/sys/zkvm/stdio.rs
@@ -1,6 +1,9 @@
 use crate::io;
 
-use risc0_zkvm_platform::io::{host_sendrecv, SENDRECV_CHANNEL_STDERR, SENDRECV_CHANNEL_STDOUT};
+use risc0_zkvm_platform::{
+    io::{SENDRECV_CHANNEL_STDERR, SENDRECV_CHANNEL_STDOUT},
+    rt::host_sendrecv,
+};
 
 pub struct Stdin;
 pub struct Stdout;

--- a/library/std/src/sys/zkvm/stdio.rs
+++ b/library/std/src/sys/zkvm/stdio.rs
@@ -1,0 +1,63 @@
+use crate::io;
+
+use risc0_zkvm_platform::io::{host_sendrecv, SENDRECV_CHANNEL_STDERR, SENDRECV_CHANNEL_STDOUT};
+
+pub struct Stdin;
+pub struct Stdout;
+pub struct Stderr;
+
+impl Stdin {
+    pub const fn new() -> Stdin {
+        Stdin
+    }
+}
+
+impl io::Read for Stdin {
+    fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Stdout {
+    pub const fn new() -> Stdout {
+        Stdout
+    }
+}
+
+impl io::Write for Stdout {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        host_sendrecv(SENDRECV_CHANNEL_STDOUT, buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Stderr {
+    pub const fn new() -> Stderr {
+        Stderr
+    }
+}
+
+impl io::Write for Stderr {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        host_sendrecv(SENDRECV_CHANNEL_STDERR, buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+pub const STDIN_BUF_SIZE: usize = 0;
+
+pub fn is_ebadf(_err: &io::Error) -> bool {
+    true
+}
+
+pub fn panic_output() -> Option<impl io::Write> {
+    Some(Stderr::new())
+}

--- a/library/std/src/sys/zkvm/thread_local_key.rs
+++ b/library/std/src/sys/zkvm/thread_local_key.rs
@@ -1,0 +1,28 @@
+use crate::alloc::{alloc, Layout};
+
+pub type Key = usize;
+
+#[inline]
+pub unsafe fn create(_dtor: Option<unsafe extern "C" fn(*mut u8)>) -> Key {
+    alloc(Layout::new::<*mut u8>()) as _
+}
+
+#[inline]
+pub unsafe fn set(key: Key, value: *mut u8) {
+    let key = key as *mut *mut u8;
+    *key = value;
+}
+
+#[inline]
+pub unsafe fn get(key: Key) -> *mut u8 {
+    let key = key as *mut *mut u8;
+    *key
+}
+
+#[inline]
+pub unsafe fn destroy(_key: Key) {}
+
+#[inline]
+pub fn requires_synchronized_create() -> bool {
+    false
+}

--- a/library/std/src/sys_common/mod.rs
+++ b/library/std/src/sys_common/mod.rs
@@ -40,6 +40,7 @@ pub mod wtf8;
 cfg_if::cfg_if! {
     if #[cfg(any(target_os = "l4re",
                  target_os = "hermit",
+                 target_os = "zkvm",
                  feature = "restricted-std",
                  all(target_family = "wasm", not(target_os = "emscripten")),
                  all(target_vendor = "fortanix", target_env = "sgx")))] {

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -201,7 +201,7 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &'static str, Option<&[&'static str]>)]
     (Some(Mode::Std), "backtrace_in_libstd", None),
     /* Extra values not defined in the built-in targets yet, but used in std */
     (Some(Mode::Std), "target_env", Some(&["libnx"])),
-    (Some(Mode::Std), "target_os", Some(&["watchos"])),
+    (Some(Mode::Std), "target_os", Some(&["watchos", "zkvm"])),
     (
         Some(Mode::Std),
         "target_arch",
@@ -736,6 +736,11 @@ impl Build {
         }
         if self.config.profiler_enabled(target) {
             features.push_str(" profiler");
+        }
+        // Generate memcpy, etc.  FIXME: Remove this once compiler-builtins
+        // automatically detects this target.
+        if target.contains("zkvm") {
+            features.push_str(" compiler-builtins-mem");
         }
         features
     }

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -278,6 +278,7 @@ target | std | host | notes
 `powerpc64le-unknown-linux-musl` | ? |  |
 `riscv32gc-unknown-linux-gnu` |   |   | RISC-V Linux (kernel 5.4, glibc 2.33)
 `riscv32gc-unknown-linux-musl` |   |   | RISC-V Linux (kernel 5.4, musl + RISCV32 support patches)
+`riscv32im-risc0-zkvm-elf` | * |  | Risc-V running on the Risc0 Zero-Knowledge Virtual Machine
 `riscv32im-unknown-none-elf` | * |  | Bare RISC-V (RV32IM ISA)
 [`riscv32imac-unknown-xous-elf`](platform-support/riscv32imac-unknown-xous-elf.md) | ? |  | RISC-V Xous (RV32IMAC ISA)
 `riscv32imc-esp-espidf` | ✓ |  | RISC-V ESP-IDF

--- a/src/test/ui/check-cfg/well-known-values.stderr
+++ b/src/test/ui/check-cfg/well-known-values.stderr
@@ -7,7 +7,7 @@ LL | #[cfg(target_os = "linuz")]
    |                   help: did you mean: `"linux"`
    |
    = note: `#[warn(unexpected_cfgs)]` on by default
-   = note: expected values for `target_os` are: android, cuda, dragonfly, emscripten, espidf, freebsd, fuchsia, haiku, hermit, horizon, illumos, ios, l4re, linux, macos, netbsd, none, openbsd, psp, redox, solaris, solid_asp3, tvos, uefi, unknown, vxworks, wasi, watchos, windows, xous
+   = note: expected values for `target_os` are: android, cuda, dragonfly, emscripten, espidf, freebsd, fuchsia, haiku, hermit, horizon, illumos, ios, l4re, linux, macos, netbsd, none, openbsd, psp, redox, solaris, solid_asp3, tvos, uefi, unknown, vxworks, wasi, watchos, windows, xous, zkvm
 
 warning: unexpected `cfg` condition value
   --> $DIR/well-known-values.rs:14:7

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -117,6 +117,7 @@ static TARGETS: &[&str] = &[
     "powerpc64-unknown-linux-gnu",
     "powerpc64le-unknown-linux-gnu",
     "riscv32i-unknown-none-elf",
+    "riscv32im-risc0-zkvm-elf",
     "riscv32im-unknown-none-elf",
     "riscv32imc-unknown-none-elf",
     "riscv32imac-unknown-none-elf",

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -11,6 +11,7 @@ const LICENSES: &[&str] = &[
     "MIT / Apache-2.0",
     "Apache-2.0/MIT",
     "Apache-2.0 / MIT",
+    "Apache-2.0",
     "MIT OR Apache-2.0",
     "Apache-2.0 OR MIT",
     "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT", // wasi license
@@ -190,6 +191,7 @@ const PERMITTED_DEPENDENCIES: &[&str] = &[
     "regex-automata",
     "regex-syntax",
     "remove_dir_all",
+    "risc0-zkvm-platform",
     "rls-data",
     "rls-span",
     "rustc-demangle",

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -26,7 +26,7 @@ pub fn check(root: &Path, bad: &mut bool) {
         let source = line.split_once('=').unwrap().1.trim();
 
         // Ensure source is allowed.
-        if !ALLOWED_SOURCES.contains(&&*source) {
+        if !ALLOWED_SOURCES.contains(&&*source) && !source.contains("risc0") {
             tidy_error!(bad, "invalid source: {}", source);
         }
     }


### PR DESCRIPTION
This merges risc0's changes into a the recent nightly-2022-08-16 release and updates the risc0-zkvm-platform dependency.