### PR TITLE
Remove dependency on risc0 from standard library.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,15 +3295,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "risc0-zkvm-platform"
-version = "0.11.1"
-source = "git+https://github.com/risc0/risc0?rev=d568b2d517e49e3fbe4d6db1e9f963e44b86c67f#d568b2d517e49e3fbe4d6db1e9f963e44b86c67f"
-dependencies = [
- "compiler_builtins",
- "rustc-std-workspace-core",
-]
-
-[[package]]
 name = "rls"
 version = "1.41.0"
 dependencies = [
@@ -5075,7 +5066,6 @@ dependencies = [
  "panic_unwind",
  "profiler_builtins",
  "rand 0.7.3",
- "risc0-zkvm-platform",
  "rustc-demangle",
  "std_detect",
  "unwind",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -47,9 +47,6 @@ hermit-abi = { version = "0.2.0", features = ['rustc-dep-of-std'] }
 [target.wasm32-wasi.dependencies]
 wasi = { version = "0.11.0", features = ['rustc-dep-of-std'], default-features = false }
 
-[target.'cfg(target_os = "zkvm")'.dependencies]
-risc0-zkvm-platform = { git = "https://github.com/risc0/risc0", rev="d568b2d517e49e3fbe4d6db1e9f963e44b86c67f", default-features = false, features = ['rustc-dep-of-std'] }
-
 [features]
 backtrace = [
   "gimli-symbolize",

--- a/library/std/src/sys/zkvm/abi.rs
+++ b/library/std/src/sys/zkvm/abi.rs
@@ -1,0 +1,5 @@
+extern "Rust" {
+    pub(crate) fn zkvm_abi_alloc_words(nwords: usize) -> *mut u32;
+    pub(crate) fn zkvm_abi_write_stdout(buf: &[u8]);
+    pub(crate) fn zkvm_abi_write_stderr(buf: &[u8]);
+}

--- a/library/std/src/sys/zkvm/alloc.rs
+++ b/library/std/src/sys/zkvm/alloc.rs
@@ -1,32 +1,21 @@
+use super::abi;
 use crate::alloc::{GlobalAlloc, Layout, System};
 use crate::cell::UnsafeCell;
-use risc0_zkvm_platform::{memory, WORD_SIZE};
 
-struct BumpPointerAlloc {
-    head: UnsafeCell<usize>,
-    end: usize,
-}
-// SAFETY: single threaded environment
-unsafe impl Sync for BumpPointerAlloc {}
-
-static mut HEAP: BumpPointerAlloc =
-    BumpPointerAlloc { head: UnsafeCell::new(memory::HEAP.start()), end: memory::HEAP.end() };
+const WORD_SIZE: usize = core::mem::size_of::<u32>();
 
 #[stable(feature = "alloc_system_type", since = "1.28.0")]
 unsafe impl GlobalAlloc for System {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let head = HEAP.head.get();
+        let nwords = layout
+            .align_to(WORD_SIZE)
+            .expect("Unable to align allocation to word size")
+            .pad_to_align()
+            .size()
+            / WORD_SIZE;
 
-        // move start up to the next alignment boundary
-        let alloc_start = (*head + WORD_SIZE) & !(WORD_SIZE - 1);
-        let alloc_end = alloc_start.checked_add(layout.size()).unwrap();
-        if alloc_end > HEAP.end {
-            panic!("out of heap");
-        } else {
-            *head = alloc_end;
-            alloc_start as *mut u8
-        }
+        abi::zkvm_abi_alloc_words(nwords) as *mut u8
     }
 
     #[inline]

--- a/library/std/src/sys/zkvm/mod.rs
+++ b/library/std/src/sys/zkvm/mod.rs
@@ -43,3 +43,5 @@ pub mod thread;
 #[deny(unsafe_op_in_unsafe_fn)]
 mod common;
 pub use common::*;
+
+mod abi;

--- a/library/std/src/sys/zkvm/stdio.rs
+++ b/library/std/src/sys/zkvm/stdio.rs
@@ -1,9 +1,5 @@
+use super::abi;
 use crate::io;
-
-use risc0_zkvm_platform::{
-    io::{SENDRECV_CHANNEL_STDERR, SENDRECV_CHANNEL_STDOUT},
-    rt::host_sendrecv,
-};
 
 pub struct Stdin;
 pub struct Stdout;
@@ -29,7 +25,8 @@ impl Stdout {
 
 impl io::Write for Stdout {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        host_sendrecv(SENDRECV_CHANNEL_STDOUT, buf);
+        unsafe { abi::zkvm_abi_write_stdout(buf) };
+
         Ok(buf.len())
     }
 
@@ -46,7 +43,8 @@ impl Stderr {
 
 impl io::Write for Stderr {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        host_sendrecv(SENDRECV_CHANNEL_STDERR, buf);
+        unsafe { abi::zkvm_abi_write_stderr(buf) };
+
         Ok(buf.len())
     }
 


### PR DESCRIPTION
Instead, declare extern "Rust" functions as an ABI and call them.  This lets us break this dependency loop.