### PR TITLE
rust standard library stdin+getenv support

### DIFF
--- a/library/std/src/sys/zkvm/abi.rs
+++ b/library/std/src/sys/zkvm/abi.rs
@@ -1,5 +1,94 @@
-extern "Rust" {
-    pub(crate) fn zkvm_abi_alloc_words(nwords: usize) -> *mut u32;
-    pub(crate) fn zkvm_abi_write_stdout(buf: &[u8]);
-    pub(crate) fn zkvm_abi_write_stderr(buf: &[u8]);
+//! ABI definitions for symbols exported by risc0-zkvm-platform.
+
+// Included here so we don't have to depend on risc0-zkvm-platform.
+//
+// TODO: Should we move this to the "libc" crate?  It seems like other
+// architectures put a lot of this kind of stuff there.  But there's
+// currently no risc0 fork of the libc crate, so we'd either have to
+// fork it or upstream it.
+
+pub const DIGEST_WORDS: usize = 8;
+
+/// Standard IO file descriptors for use with sys_read and sys_write.
+pub mod fileno {
+    pub const STDIN: u32 = 0;
+    pub const STDOUT: u32 = 1;
+    pub const STDERR: u32 = 2;
+    pub const JOURNAL: u32 = 3;
+}
+
+extern "C" {
+    // Syscall names are all nul-terminated c-style string.  Raw access to syscalls:
+    pub fn syscall_0(name: *const u8, from_host: *mut u32, from_host_words: usize) -> (u32, u32);
+    pub fn syscall_1(
+        name: *const u8,
+        from_host: *mut u32,
+        from_host_words: usize,
+        a3: u32,
+    ) -> (u32, u32);
+    pub fn syscall_2(
+        name: *const u8,
+        from_host: *mut u32,
+        from_host_words: usize,
+        a3: u32,
+        a4: u32,
+    ) -> (u32, u32);
+    pub fn syscall_3(
+        name: *const u8,
+        from_host: *mut u32,
+        from_host_words: usize,
+        a3: u32,
+        a4: u32,
+        a5: u32,
+    ) -> (u32, u32);
+    pub fn syscall_4(
+        name: *const u8,
+        from_host: *mut u32,
+        from_host_words: usize,
+        a3: u32,
+        a4: u32,
+        a5: u32,
+        a6: u32,
+    ) -> (u32, u32);
+    pub fn syscall_5(
+        name: *const u8,
+        from_host: *mut u32,
+        from_host_words: usize,
+        a3: u32,
+        a4: u32,
+        a5: u32,
+        a6: u32,
+        a7: u32,
+    ) -> (u32, u32);
+
+    // Wrappers around syscalls provided by risc0-zkvm-platform:
+    pub fn sys_halt();
+    pub fn sys_output(output_id: u32, output_value: u32);
+    pub fn sys_sha_compress(
+        out_state: *mut [u32; DIGEST_WORDS],
+        in_state: *const [u32; DIGEST_WORDS],
+        block1_ptr: *const [u32; DIGEST_WORDS],
+        block2_ptr: *const [u32; DIGEST_WORDS],
+    );
+    pub fn sys_sha_buffer(
+        out_state: *mut [u32; DIGEST_WORDS],
+        in_state: *const [u32; DIGEST_WORDS],
+        buf: *const u8,
+        count: u32,
+    );
+    pub fn sys_rand(recv_buf: *mut u32, words: usize);
+    pub fn sys_panic(msg_ptr: *const u8, len: usize) -> !;
+    pub fn sys_log(msg_ptr: *const u8, len: usize);
+    pub fn sys_cycle_count() -> usize;
+    pub fn sys_read(fd: u32, recv_buf: *mut u8, nrequested: usize) -> usize;
+    pub fn sys_write(fd: u32, write_buf: *const u8, nbytes: usize);
+    pub fn sys_getenv(
+        recv_buf: *mut u32,
+        words: usize,
+        varname: *const u8,
+        varname_len: usize,
+    ) -> usize;
+
+    // Allocate memory from global HEAP.
+    pub fn sys_alloc_words(nwords: usize) -> *mut u32;
 }

--- a/library/std/src/sys/zkvm/alloc.rs
+++ b/library/std/src/sys/zkvm/alloc.rs
@@ -1,8 +1,6 @@
-use super::abi;
+use super::{abi, WORD_SIZE};
 use crate::alloc::{GlobalAlloc, Layout, System};
 use crate::cell::UnsafeCell;
-
-const WORD_SIZE: usize = core::mem::size_of::<u32>();
 
 #[stable(feature = "alloc_system_type", since = "1.28.0")]
 unsafe impl GlobalAlloc for System {
@@ -15,7 +13,7 @@ unsafe impl GlobalAlloc for System {
             .size()
             / WORD_SIZE;
 
-        abi::zkvm_abi_alloc_words(nwords) as *mut u8
+        abi::sys_alloc_words(nwords) as *mut u8
     }
 
     #[inline]

--- a/library/std/src/sys/zkvm/mod.rs
+++ b/library/std/src/sys/zkvm/mod.rs
@@ -7,6 +7,8 @@
 //! wide/production use yet, it's still all in the experimental category. This
 //! will likely change over time.
 
+const WORD_SIZE: usize = core::mem::size_of::<u32>();
+
 pub mod alloc;
 #[path = "../unsupported/args.rs"]
 pub mod args;
@@ -19,7 +21,6 @@ pub mod fs;
 pub mod io;
 #[path = "../unsupported/net.rs"]
 pub mod net;
-#[path = "../unsupported/os.rs"]
 pub mod os;
 #[path = "../unix/os_str.rs"]
 pub mod os_str;

--- a/library/std/src/sys/zkvm/os.rs
+++ b/library/std/src/sys/zkvm/os.rs
@@ -1,0 +1,125 @@
+use super::{abi, unsupported, WORD_SIZE};
+use crate::error::Error as StdError;
+use crate::ffi::{OsStr, OsString};
+use crate::fmt;
+use crate::io;
+use crate::marker::PhantomData;
+use crate::path::{self, PathBuf};
+use crate::sys_common::FromInner;
+
+pub fn errno() -> i32 {
+    0
+}
+
+pub fn error_string(_errno: i32) -> String {
+    "operation successful".to_string()
+}
+
+pub fn getcwd() -> io::Result<PathBuf> {
+    unsupported()
+}
+
+pub fn chdir(_: &path::Path) -> io::Result<()> {
+    unsupported()
+}
+
+pub struct SplitPaths<'a>(!, PhantomData<&'a ()>);
+
+pub fn split_paths(_unparsed: &OsStr) -> SplitPaths<'_> {
+    panic!("unsupported")
+}
+
+impl<'a> Iterator for SplitPaths<'a> {
+    type Item = PathBuf;
+    fn next(&mut self) -> Option<PathBuf> {
+        self.0
+    }
+}
+
+#[derive(Debug)]
+pub struct JoinPathsError;
+
+pub fn join_paths<I, T>(_paths: I) -> Result<OsString, JoinPathsError>
+where
+    I: Iterator<Item = T>,
+    T: AsRef<OsStr>,
+{
+    Err(JoinPathsError)
+}
+
+impl fmt::Display for JoinPathsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        "not supported on this platform yet".fmt(f)
+    }
+}
+
+impl StdError for JoinPathsError {
+    #[allow(deprecated)]
+    fn description(&self) -> &str {
+        "not supported on this platform yet"
+    }
+}
+
+pub fn current_exe() -> io::Result<PathBuf> {
+    unsupported()
+}
+
+pub struct Env(!);
+
+impl Iterator for Env {
+    type Item = (OsString, OsString);
+    fn next(&mut self) -> Option<(OsString, OsString)> {
+        self.0
+    }
+}
+
+pub fn env() -> Env {
+    panic!("not supported on this platform")
+}
+
+pub fn getenv(varname: &OsStr) -> Option<OsString> {
+    let varname = varname.bytes();
+    let nbytes =
+        unsafe { abi::sys_getenv(crate::ptr::null_mut(), 0, varname.as_ptr(), varname.len()) };
+    if nbytes == usize::MAX {
+        return None;
+    }
+
+    let nwords = (nbytes + WORD_SIZE - 1) / WORD_SIZE;
+    let words = unsafe { abi::sys_alloc_words(nwords) };
+
+    let nbytes2 = unsafe { abi::sys_getenv(words, nwords, varname.as_ptr(), varname.len()) };
+    debug_assert_eq!(nbytes, nbytes2);
+
+    // Convert to OsString.
+    //
+    // TODO: We can probably get rid of the extra copy here if we
+    // reimplement "os_str" instead of just using the generic unix
+    // "os_str".
+    let u8s: &[u8] = unsafe { crate::slice::from_raw_parts(words.cast() as *const u8, nbytes) };
+    Some(OsString::from_inner(super::os_str::Buf { inner: u8s.to_vec() }))
+}
+
+pub fn setenv(_: &OsStr, _: &OsStr) -> io::Result<()> {
+    Err(io::const_io_error!(io::ErrorKind::Unsupported, "cannot set env vars on this platform"))
+}
+
+pub fn unsetenv(_: &OsStr) -> io::Result<()> {
+    Err(io::const_io_error!(io::ErrorKind::Unsupported, "cannot unset env vars on this platform"))
+}
+
+pub fn temp_dir() -> PathBuf {
+    panic!("no filesystem on this platform")
+}
+
+pub fn home_dir() -> Option<PathBuf> {
+    None
+}
+
+pub fn exit(_code: i32) -> ! {
+    crate::intrinsics::abort()
+}
+
+pub fn getpid() -> u32 {
+    panic!("no pids on this platform")
+}

--- a/library/std/src/sys/zkvm/stdio.rs
+++ b/library/std/src/sys/zkvm/stdio.rs
@@ -1,4 +1,4 @@
-use super::abi;
+use super::{abi, abi::fileno};
 use crate::io;
 
 pub struct Stdin;
@@ -12,8 +12,8 @@ impl Stdin {
 }
 
 impl io::Read for Stdin {
-    fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
-        Ok(0)
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        Ok(unsafe { abi::sys_read(fileno::STDIN, buf.as_mut_ptr(), buf.len()) })
     }
 }
 
@@ -25,7 +25,7 @@ impl Stdout {
 
 impl io::Write for Stdout {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        unsafe { abi::zkvm_abi_write_stdout(buf) };
+        unsafe { abi::sys_write(fileno::STDOUT, buf.as_ptr(), buf.len()) }
 
         Ok(buf.len())
     }
@@ -43,7 +43,7 @@ impl Stderr {
 
 impl io::Write for Stderr {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        unsafe { abi::zkvm_abi_write_stderr(buf) };
+        unsafe { abi::sys_write(fileno::STDERR, buf.as_ptr(), buf.len()) }
 
         Ok(buf.len())
     }
@@ -53,7 +53,7 @@ impl io::Write for Stderr {
     }
 }
 
-pub const STDIN_BUF_SIZE: usize = 0;
+pub const STDIN_BUF_SIZE: usize = crate::sys_common::io::DEFAULT_BUF_SIZE;
 
 pub fn is_ebadf(_err: &io::Error) -> bool {
     true


### PR DESCRIPTION
* Update rust standard library to reference "`sys_*`" symbols exported by risc0-zkvm-platform instead of old `zkvm_abi_*`
* Add support for getting environment variables through sys_getenv
* Change stdin/stdout/stderr to use sys_read and sys_write with standard file descriptors