### PR TITLE
Use sys_alloc_aligned for allocation to support larger alignments

### DIFF
--- a/library/std/src/sys/zkvm/abi.rs
+++ b/library/std/src/sys/zkvm/abi.rs
@@ -49,4 +49,5 @@ extern "C" {
 
     // Allocate memory from global HEAP.
     pub fn sys_alloc_words(nwords: usize) -> *mut u32;
+    pub fn sys_alloc_aligned(nwords: usize, align: usize) -> *mut u8;
 }

--- a/library/std/src/sys/zkvm/alloc.rs
+++ b/library/std/src/sys/zkvm/alloc.rs
@@ -5,14 +5,7 @@ use crate::alloc::{GlobalAlloc, Layout, System};
 unsafe impl GlobalAlloc for System {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let nwords = layout
-            .align_to(WORD_SIZE)
-            .expect("Unable to align allocation to word size")
-            .pad_to_align()
-            .size()
-            / WORD_SIZE;
-
-        abi::sys_alloc_words(nwords) as *mut u8
+        abi::sys_alloc_aligned(layout.size(), layout.align())
     }
 
     #[inline]


### PR DESCRIPTION
Use the `sys_alloc_aligned` function added in https://github.com/risc0/risc0/pull/590 for allocations to support developer specified alignments of greater than a word.

Based on work by @shkoo 