### PR TITLE
Updates for Rust 1.94.1

### DIFF
--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -1,0 +1,55 @@
+name: rustup toolchain install
+description: Install the Rust toolchain
+
+inputs:
+  toolchain:
+    description: 'Identifier of the rust toolchain to install'
+    required: false
+    default: 'stable'
+    type: string
+  targets:
+    description: 'Rust compiler targets to install, as a space-delimited list'
+    required: false
+    default: ''
+    type: string
+  components:
+    description: 'List of components to install via rustup, as a space-delimited list'
+    required: false
+    default: ''
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - run: |
+        if ! command -v rustup &>/dev/null; then
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        fi
+      shell: bash
+
+    - run: rustup override unset
+      shell: bash
+
+    - run: rustup default ${{ inputs.toolchain }}
+      shell: bash
+
+    - if: ${{ inputs.targets != '' }}
+      run: rustup target add ${{ inputs.targets }}
+      shell: bash
+
+    - if: ${{ inputs.components != '' }}
+      run: rustup component add ${{ inputs.components }}
+      shell: bash
+
+    - run: |
+        echo "CARGO_NET_RETRY=10" >> $GITHUB_ENV
+        echo "CARGO_TERM_COLOR=always" >> $GITHUB_ENV
+        echo "RUSTUP_MAX_RETRIES=10" >> $GITHUB_ENV
+      shell: bash
+
+    - run: rustup show active-toolchain || rustup toolchain install
+      shell: bash
+
+    - run: rustc --version --verbose
+      shell: bash

--- a/.github/containers/release/Dockerfile
+++ b/.github/containers/release/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:22.04 as base
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && \
+    apt -y install \
+        build-essential \
+        cmake \
+        curl \
+        git \
+        libssl-dev \
+        ninja-build \
+        pkg-config \
+        python3 \
+        zlib1g-dev
+
+RUN curl -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+ENV RISC0_HOME="/risc0"
+
+WORKDIR /src
+
+FROM base AS builder
+COPY . .
+
+RUN ls -al rust/.git
+
+WORKDIR /src/risc0
+RUN --mount=type=cache,id=release,target=/root/.cache \
+  --mount=type=cache,id=release,target=/root/.cargo,from=base,source=/root/.cargo \
+  cargo build --bin rzup
+
+RUN mkdir -p /risc0
+
+RUN --mount=type=cache,id=release,target=/root/.cache \
+  --mount=type=cache,id=release,target=/root/.cargo,from=base,source=/root/.cargo \
+  target/debug/rzup build rust --path /src/rust
+
+FROM scratch AS export
+COPY --from=builder /risc0/toolchains/ /

--- a/.github/containers/release/Dockerfile.dockerignore
+++ b/.github/containers/release/Dockerfile.dockerignore
@@ -1,0 +1,5 @@
+**/Dockerfile
+**/.git
+**/node_modules
+**/target
+**/tmp

--- a/.github/containers/release/Dockerfile.dockerignore
+++ b/.github/containers/release/Dockerfile.dockerignore
@@ -1,5 +1,0 @@
-**/Dockerfile
-**/.git
-**/node_modules
-**/target
-**/tmp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,10 @@ jobs:
           path: risc0
 
       - name: set RISC0_HOME
-        run: echo "RISC0_HOME=$GITHUB_WORKSPACE/rzup_artifacts" >> $GITHUB_ENV
+        run: echo "RISC0_HOME=$GITHUB_WORKSPACE/rzup_artifacts_${{ github.ref_name }}" >> $GITHUB_ENV
+
+      - name: clear out RISC0_HOME
+        run: rm -rf $RISC0_HOME
 
       - name: Build
         run: GITHUB_ACTIONS=false cargo run --bin rzup -- build rust --path $GITHUB_WORKSPACE/rust
@@ -56,7 +59,7 @@ jobs:
             --exclude lib/rustlib/rustc-src \
             -hczvf \
             ./rust-toolchain-${{ matrix.triple }}.tar.gz \
-            -C $GITHUB_WORKSPACE/rzup_artifacts/toolchains/*rust*/ \
+            -C $RISC0_HOME/toolchains/*rust*/ \
             .
         working-directory: rust
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - os: Linux
             arch: X64
             triple: x86_64-unknown-linux-gnu
-    runs-on: [ self-hosted, release, "${{ matrix.os }}", "${{ matrix.arch }}" ]
+    runs-on: [ self-hosted, cluster, "${{ matrix.os }}", "${{ matrix.arch }}" ]
     steps:
       - name: Install Rust
         uses: risc0/actions-rs-toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,7 @@ jobs:
     runs-on: [ self-hosted, cluster, "${{ matrix.os }}", "${{ matrix.arch }}" ]
     steps:
       - name: Install Rust
-        uses: risc0/actions-rs-toolchain@v1
-        with:
-            toolchain: stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Check out risc0/rust
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
         uses: risc0/actions-rs-toolchain@v1
         with:
             toolchain: stable
-      - uses: lukka/get-cmake@v3.27.4
 
       - name: Check out risc0/rust
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,7 @@ jobs:
         run: rm -rf $RISC0_HOME
 
       - if: matrix.os == 'Linux'
-        run: |
-          cp rust/.github/containers/release/Dockerfile ./
-          docker build -f Dockerfile --output $RISC0_HOME/toolchains .
+        run: docker build -f rust/.github/containers/release/Dockerfile --output $RISC0_HOME/toolchains .
 
       - if: matrix.os == 'macOS'
         run: GITHUB_ACTIONS=false cargo run --bin rzup -- build rust --path $GITHUB_WORKSPACE/rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,326 +1,67 @@
-# This file defines our primary CI workflow that runs on pull requests
-# and also on pushes to special branches (auto, try).
-#
-# The actual definition of the executed jobs is calculated by the
-# `src/ci/citool` crate, which
-# uses job definition data from src/ci/github-actions/jobs.yml.
-# You should primarily modify the `jobs.yml` file if you want to modify
-# what jobs are executed in CI.
-
 name: CI
+
 on:
   push:
-    branches:
-      - automation/bors/auto
-      - automation/bors/try
-      - try-perf
+    branches: [ risc0 ]
   pull_request:
-    branches:
-      - "**"
+    branches: [ risc0, "risc0-*" ]
+  workflow_call:
+  workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
-
-defaults:
-  run:
-    # On Linux, macOS, and Windows, use the system-provided bash as the default
-    # shell. (This should only make a difference on Windows, where the default
-    # shell is PowerShell.)
-    shell: bash
-
-concurrency:
-  # For a given workflow, if we push to the same branch, cancel all previous builds on that branch.
-  # We add an exception for try builds (automation/bors/try branch) and unrolled rollup builds
-  # (try-perf), which are all triggered on the same branch, but which should be able to run
-  # concurrently.
-  group: ${{ github.workflow }}-${{ ((github.ref == 'refs/heads/try-perf' || github.ref == 'refs/heads/automation/bors/try') && github.sha) || github.ref }}
-  cancel-in-progress: true
-env:
-  TOOLSTATE_REPO: "https://github.com/rust-lang-nursery/rust-toolstate"
-  # This will be empty in PR jobs.
-  TOOLSTATE_REPO_ACCESS_TOKEN: ${{ secrets.TOOLSTATE_REPO_ACCESS_TOKEN }}
 jobs:
-  # The job matrix for `calculate_matrix` is defined in src/ci/github-actions/jobs.yml.
-  # It calculates which jobs should be executed, based on the data of the ${{ github }} context.
-  # If you want to modify CI jobs, take a look at src/ci/github-actions/jobs.yml.
-  calculate_matrix:
-    name: Calculate job matrix
-    runs-on: ubuntu-24.04-arm
-    outputs:
-      jobs: ${{ steps.jobs.outputs.jobs }}
-      run_type: ${{ steps.jobs.outputs.run_type }}
-    steps:
-      - name: Checkout the source code
-        uses: actions/checkout@v5
-      - name: Test citool
-        # Only test citool on the auto branch, to reduce latency of the calculate matrix job
-        # on PR/try builds.
-        if: ${{ github.ref == 'refs/heads/automation/bors/auto' }}
-        run: |
-          cd src/ci/citool
-          CARGO_INCREMENTAL=0 cargo test
-      - name: Calculate the CI job matrix
-        env:
-          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-        run: |
-          cd src/ci/citool
-          CARGO_INCREMENTAL=0 cargo run calculate-job-matrix >> $GITHUB_OUTPUT
-        id: jobs
-  job:
-    name: ${{ matrix.full_name }}
-    needs: [ calculate_matrix ]
-    runs-on: "${{ matrix.os }}"
-    timeout-minutes: 360
-    # The bors environment contains secrets required for elevated workflows (try and auto builds),
-    # which need to access e.g. S3 and upload artifacts. We want to provide access to that
-    # environment only on the try/auto branches, which are only accessible to bors.
-    # This also ensures that PR CI (which doesn't get write access to S3) works, as it cannot
-    # access the environment.
-    #
-    # We only enable the environment for the rust-lang/rust repository, so that CI works on forks.
-    environment: ${{ ((github.repository == 'rust-lang/rust' && (github.ref == 'refs/heads/try-perf' || github.ref == 'refs/heads/automation/bors/try' || github.ref == 'refs/heads/automation/bors/auto')) && 'bors') || '' }}
-    env:
-      CI_JOB_NAME: ${{ matrix.name }}
-      CI_JOB_DOC_URL: ${{ matrix.doc_url }}
-      GITHUB_WORKFLOW_RUN_ID: ${{ github.run_id }}
-      GITHUB_REPOSITORY: ${{ github.repository }}
-      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-      # commit of PR sha or commit sha. `GITHUB_SHA` is not accurate for PRs.
-      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      DOCKER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SCCACHE_BUCKET: rust-lang-ci-sccache2
-      SCCACHE_REGION: us-west-1
-      CACHE_DOMAIN: ci-caches.rust-lang.org
-    continue-on-error: ${{ matrix.continue_on_error || false }}
+  build:
     strategy:
+      fail-fast: false
       matrix:
-        # Check the `calculate_matrix` job to see how is the matrix defined.
-        include: ${{ fromJSON(needs.calculate_matrix.outputs.jobs) }}
+        include:
+          - os: macOS
+            arch: ARM64
+            triple: aarch64-apple-darwin
+          - os: Linux
+            arch: X64
+            triple: x86_64-unknown-linux-gnu
+    runs-on: [ self-hosted, release, "${{ matrix.os }}", "${{ matrix.arch }}" ]
     steps:
-      - name: Install cargo in AWS CodeBuild
-        if: matrix.codebuild
-        run: |
-          # Check if cargo is installed
-          if ! command -v cargo &> /dev/null; then
-            echo "Cargo not found, installing Rust..."
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal
-            # Make cargo available in PATH
-            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          fi
-
-      - name: disable git crlf conversion
-        run: git config --global core.autocrlf false
-
-      - name: checkout the source code
-        uses: actions/checkout@v5
+      - name: Install Rust
+        uses: risc0/actions-rs-toolchain@v1
         with:
-          fetch-depth: 2
+            toolchain: stable
+      - uses: lukka/get-cmake@v3.27.4
 
-      # Free up disk space on Linux by removing preinstalled components that
-      # we do not need. We do this to enable some of the less resource
-      # intensive jobs to run on free runners, which however also have
-      # less disk space.
-      - name: free up disk space
-        run: src/ci/scripts/free-disk-space-linux.sh
-        if: matrix.free_disk
-
-      # If we don't need to free up disk space then just report how much space we have
-      - name: print disk usage
-        run: |
-          echo "disk usage:"
-          df -h
-        if: matrix.free_disk == false
-
-      # Rust Log Analyzer can't currently detect the PR number of a GitHub
-      # Actions build on its own, so a hint in the log message is needed to
-      # point it in the right direction.
-      - name: configure the PR in which the error message will be posted
-        run: echo "[CI_PR_NUMBER=$num]"
-        env:
-          num: ${{ github.event.number }}
-        if: needs.calculate_matrix.outputs.run_type == 'pr'
-
-      - name: add extra environment variables
-        run: src/ci/scripts/setup-environment.sh
-        env:
-          # Since it's not possible to merge `${{ matrix.env }}` with the other
-          # variables in `job.<name>.env`, the variables defined in the matrix
-          # are passed to the `setup-environment.sh` script encoded in JSON,
-          # which then uses log commands to actually set them.
-          EXTRA_VARIABLES: ${{ toJson(matrix.env) }}
-
-      - name: ensure the channel matches the target branch
-        run: src/ci/scripts/verify-channel.sh
-
-      - name: collect CPU statistics
-        run: src/ci/scripts/collect-cpu-stats.sh
-
-      - name: show the current environment
-        run: src/ci/scripts/dump-environment.sh
-
-      - name: install awscli
-        run: src/ci/scripts/install-awscli.sh
-
-      - name: install sccache
-        run: src/ci/scripts/install-sccache.sh
-
-      - name: select Xcode
-        run: src/ci/scripts/select-xcode.sh
-
-      - name: install clang
-        run: src/ci/scripts/install-clang.sh
-
-      - name: install tidy
-        run: src/ci/scripts/install-tidy.sh
-
-      - name: install WIX
-        run: src/ci/scripts/install-wix.sh
-
-      - name: disable git crlf conversion
-        run: src/ci/scripts/disable-git-crlf-conversion.sh
-
-      - name: checkout submodules
-        run: src/ci/scripts/checkout-submodules.sh
-
-      - name: install MinGW
-        run: src/ci/scripts/install-mingw.sh
-
-      - name: install ninja
-        run: src/ci/scripts/install-ninja.sh
-
-      - name: enable ipv6 on Docker
-        # Don't run on codebuild because systemctl is not available
-        if: ${{ !matrix.codebuild }}
-        run: src/ci/scripts/enable-docker-ipv6.sh
-
-      # Disable automatic line ending conversion (again). On Windows, when we're
-      # installing dependencies, something switches the git configuration directory or
-      # re-enables autocrlf. We've not tracked down the exact cause -- and there may
-      # be multiple -- but this should ensure submodules are checked out with the
-      # appropriate line endings.
-      - name: disable git crlf conversion
-        run: src/ci/scripts/disable-git-crlf-conversion.sh
-
-      - name: ensure line endings are correct
-        run: src/ci/scripts/verify-line-endings.sh
-
-      - name: ensure backported commits are in upstream branches
-        run: src/ci/scripts/verify-backported-commits.sh
-
-      - name: ensure the stable version number is correct
-        run: src/ci/scripts/verify-stable-version-number.sh
-
-      # Show the environment just before we run the build
-      # This makes it easier to diagnose problems with the above install scripts.
-      - name: show the current environment
-        run: src/ci/scripts/dump-environment.sh
-
-      # Pre-build citool before the following step uninstalls rustup
-      # Build it into the build directory, to avoid modifying sources
-      - name: build citool
-        run: |
-          cd src/ci/citool
-          CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=../../../build/citool cargo build
-
-      - name: run the build
-        run: |
-          set +e
-          # Redirect stderr to stdout to avoid reordering the two streams in the GHA logs.
-          src/ci/scripts/run-build-from-ci.sh 2>&1
-          STATUS=$?
-          set -e
-
-          if [[ "$STATUS" -ne 0 && -n "$CI_JOB_DOC_URL" ]]; then
-            echo "****************************************************************************"
-            echo "To find more information about this job, visit the following URL:"
-            echo "$CI_JOB_DOC_URL"
-            echo "****************************************************************************"
-          fi
-          exit ${STATUS}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.CACHES_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CACHES_AWS_SECRET_ACCESS_KEY }}
-
-      - name: create github artifacts
-        run: src/ci/scripts/create-doc-artifacts.sh
-
-      - name: print disk usage
-        # We also want to know the disk usage when the job fails.
-        if: always()
-        run: |
-          echo "disk usage:"
-          df -h
-
-      - name: upload artifacts to github
-        uses: actions/upload-artifact@v4
+      - name: Check out risc0/rust
+        uses: actions/checkout@v3
         with:
-          # name is set in previous step
-          name: ${{ env.DOC_ARTIFACT_NAME }}
-          path: obj/artifacts/doc
-          if-no-files-found: ignore
-          retention-days: 5
+          submodules: 'recursive'
+          path: rust
+          fetch-depth: 0
 
-      - name: upload artifacts to S3
-        run: src/ci/scripts/upload-artifacts.sh
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.ARTIFACTS_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.ARTIFACTS_AWS_SECRET_ACCESS_KEY }}
-        # Adding a condition on DEPLOY=1 or DEPLOY_ALT=1 is not needed as all deploy
-        # builders *should* have the AWS credentials available. Still, explicitly
-        # adding the condition is helpful as this way CI will not silently skip
-        # deploying artifacts from a dist builder if the variables are misconfigured,
-        # erroring about invalid credentials instead.
-        if: github.event_name == 'push' || env.DEPLOY == '1' || env.DEPLOY_ALT == '1'
-
-      - name: postprocess metrics into the summary
-        # This step is not critical, and if some I/O problem happens, we don't want
-        # to cancel the build.
-        continue-on-error: true
-        run: |
-          if [ -f build/metrics.json ]; then
-            METRICS=build/metrics.json
-          elif [ -f obj/build/metrics.json ]; then
-            METRICS=obj/build/metrics.json
-          else
-            echo "No metrics.json found"
-            exit 0
-          fi
-
-          # Get closest bors merge commit
-          PARENT_COMMIT=`git rev-list --author='bors@rust-lang.org' --author='122020455+rust-bors\[bot\]@users.noreply.github.com' -n1 --first-parent HEAD^1`
-
-          ./build/citool/debug/citool postprocess-metrics \
-              --job-name ${CI_JOB_NAME} \
-              --parent ${PARENT_COMMIT} \
-              ${METRICS} >> ${GITHUB_STEP_SUMMARY}
-
-      - name: upload job metrics to DataDog
-        # This step is not critical, and if some I/O problem happens, we don't want
-        # to cancel the build.
-        continue-on-error: true
-        if: needs.calculate_matrix.outputs.run_type != 'pr'
-        env:
-          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-          DD_GITHUB_JOB_NAME: ${{ matrix.full_name }}
-        run: ./build/citool/debug/citool upload-build-metrics build/cpu-usage.csv
-
-  # This job is used to publish toolstate for successful auto builds.
-  outcome:
-    name: publish toolstate
-    runs-on: ubuntu-24.04
-    needs: [ calculate_matrix, job ]
-    if: ${{ needs.calculate_matrix.outputs.run_type == 'auto' }}
-    environment: ${{ (github.repository == 'rust-lang/rust' && 'bors') || '' }}
-    steps:
-      - name: checkout the source code
-        uses: actions/checkout@v5
+      - name: Check out risc0/risc0
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 2
-      # Publish the toolstate if an auto build succeeds (just before push to the default branch)
-      - name: publish toolstate
-        run: src/ci/publish_toolstate.sh
-        shell: bash
-        env:
-          TOOLSTATE_ISSUES_API_URL: https://api.github.com/repos/rust-lang/rust/issues
-          TOOLSTATE_PUBLISH: 1
+          repository: risc0/risc0
+          ref: main
+          path: risc0
+
+      - name: set RISC0_HOME
+        run: echo "RISC0_HOME=$GITHUB_WORKSPACE/rzup_artifacts" >> $GITHUB_ENV
+
+      - name: Build
+        run: GITHUB_ACTIONS=false cargo run --bin rzup -- build rust --path $GITHUB_WORKSPACE/rust
+        working-directory: risc0
+
+      - name: "Archive toolchain"
+        run: |
+          tar \
+            --exclude lib/rustlib/src \
+            --exclude lib/rustlib/rustc-src \
+            -hczvf \
+            ./rust-toolchain-${{ matrix.triple }}.tar.gz \
+            -C $GITHUB_WORKSPACE/rzup_artifacts/toolchains/*rust*/ \
+            .
+        working-directory: rust
+
+      - name: "Upload workflow artifact"
+        uses: "actions/upload-artifact@v4"
+        with:
+          name: "rust-toolchain-${{ matrix.triple }}.tar.gz"
+          path: "rust/rust-toolchain-${{ matrix.triple }}.tar.gz"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,15 @@ jobs:
             triple: x86_64-unknown-linux-gnu
     runs-on: [ self-hosted, cluster, "${{ matrix.os }}", "${{ matrix.arch }}" ]
     steps:
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
       - name: Check out risc0/rust
         uses: actions/checkout@v3
         with:
           submodules: 'recursive'
           path: rust
           fetch-depth: 0
+
+      - name: Install Rust
+        uses: ./rust/.github/actions/rustup
 
       - name: Check out risc0/risc0
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,12 @@ jobs:
       - name: clear out RISC0_HOME
         run: rm -rf $RISC0_HOME
 
-      - name: Build
+      - if: matrix.os == 'Linux'
+        run: |
+          cp rust/.github/containers/release/Dockerfile ./
+          docker build -f Dockerfile --output $RISC0_HOME/toolchains .
+
+      - if: matrix.os == 'macOS'
         run: GITHUB_ACTIONS=false cargo run --bin rzup -- build rust --path $GITHUB_WORKSPACE/rust
         working-directory: risc0
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -28,7 +28,7 @@ jobs:
   not-waiting-on-bors:
     if: github.repository_owner == 'rust-lang'
     name: skip if S-waiting-on-bors
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -48,7 +48,7 @@ jobs:
     if: github.repository_owner == 'rust-lang'
     name: update dependencies
     needs: not-waiting-on-bors
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout the source code
         uses: actions/checkout@v5
@@ -62,27 +62,14 @@ jobs:
           rustup toolchain install --no-self-update --profile minimal $TOOLCHAIN
           rustup default $TOOLCHAIN
 
-      - name: cargo update compiler & tools
+      - name: cargo update
         # Remove first line that always just says "Updating crates.io index"
-        run: |
-          echo -e "\ncompiler & tools dependencies:" >> cargo_update.log
-          cargo update 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
-      - name: cargo update library
-        run: |
-          echo -e "\nlibrary dependencies:" >> cargo_update.log
-          cargo update --manifest-path library/Cargo.toml 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
-      - name: cargo update rustbook
-        run: |
-          echo -e "\nrustbook dependencies:" >> cargo_update.log
-          cargo update --manifest-path src/tools/rustbook/Cargo.toml 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
+        run: cargo update 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
       - name: upload Cargo.lock artifact for use in PR
         uses: actions/upload-artifact@v4
         with:
           name: Cargo-lock
-          path: |
-            Cargo.lock
-            library/Cargo.lock
-            src/tools/rustbook/Cargo.lock
+          path: Cargo.lock
           retention-days: 1
       - name: upload cargo-update log artifact for use in PR
         uses: actions/upload-artifact@v4
@@ -95,7 +82,7 @@ jobs:
     if: github.repository_owner == 'rust-lang'
     name: amend PR
     needs: update
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
@@ -127,7 +114,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git switch --force-create cargo_update
-          git add ./Cargo.lock ./library/Cargo.lock ./src/tools/rustbook/Cargo.lock
+          git add ./Cargo.lock
           git commit --no-verify --file=commit.txt
 
       - name: push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+    uses: ./.github/workflows/ci.yml
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: artifacts
+        merge-multiple: true
+    - name: Display structure of downloaded artifacts
+      run: ls -R ./artifacts
+    - name: Create release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo "Installing gh CLI..."
+        curl -L https://github.com/cli/cli/releases/download/v2.17.0/gh_2.17.0_linux_amd64.tar.gz | \
+          tar xvz  --strip-components=2 --exclude=man
+        chmod +x ./gh
+
+        ./gh release create --repo "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" ./artifacts/* || \
+        ./gh release upload --repo "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" ./artifacts/*


### PR DESCRIPTION
This contains changes to make the 1.94.1 release branch build with risc0 CI. The changes are mostly ported over from the last release branch.

There were also some changes made that are specific to recent CI runner / configuration changes.

A "+alpha" version of the toolchain was built and CI ran on risc0 main and release-3.0 to validate the toolchain works.